### PR TITLE
feat: .gitignoreに.vite/を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ coverage
 test-results/
 playwright-report/
 
+.vite/
 
 /CubismSdkForWeb/
 /public/Core


### PR DESCRIPTION
.vite/ディレクトリを.gitignoreに追加し、ビルドツールの生成物を無視するように設定しました。