### PR TITLE
fix: splitSentence関数の文分割ロジックを修正

### DIFF
--- a/src/utils/voicevox/splitSentence.ts
+++ b/src/utils/voicevox/splitSentence.ts
@@ -7,6 +7,6 @@
  */
 export function splitSentence(text: string): string[] {
   // 句読点や改行で文を区切るための正規表現
-  const pattern = /(?<=[。？！\.\,])|\r?\n/
-  return text.split(pattern)
+  const pattern = /(?<=[。？！\.\,\?\!])(?![。？！\.\,\?\!])/
+  return text.replace(/[\r\n]/g, '').split(pattern)
 }


### PR DESCRIPTION
- 文の区切りを句読点の後に変更し、連続する句読点を考慮するように修正
- 改行を削除してから文を分割するように変更