### PR TITLE
feat: コーデック情報の定義とビデオエンコーダ設定の改善

### DIFF
--- a/src/components/VideoRenderView/VParagraphsEditor.vue
+++ b/src/components/VideoRenderView/VParagraphsEditor.vue
@@ -48,7 +48,7 @@ watch(() => [...paragraphs.value.map(p => p.start), ...paragraphs.value.map(p =>
     paragraph.start = prev;
     paragraph.end = prev + duration;
     return paragraph.end;
-  }, 0);
+  }, paragraphs.value[0]?.start ?? 0);
 });
 
 function onFocusParagraph(paragraph: Paragraph) {

--- a/src/utils/app/CharacterChatWithExpression.ts
+++ b/src/utils/app/CharacterChatWithExpression.ts
@@ -27,14 +27,16 @@ export class CharacterChatWithExpression {
       type: 'function',
       function: {
         name: 'change_character_expression',
-        description: "Change the character's expression",
+        description:
+          "Change the character's expression to one of the predefined types. This function is used to visually represent the character's emotional state during the conversation.",
         parameters: {
           type: 'object',
           properties: {
             expressionType: {
               type: 'string',
               enum: ['normal', 'happy', 'sad', 'angry', 'surprised', 'blush'],
-              description: 'Expression',
+              description:
+                'The type of expression to change to. Must be one of the following: "normal", "happy", "sad", "angry", "surprised", or "blush".',
             },
           },
           required: ['expressionType'],
@@ -51,7 +53,7 @@ export class CharacterChatWithExpression {
     `,
   }
   // 会話履歴の数がこの数以上になったら要約する
-  protected summarizeLength = 5
+  protected summarizeLength = 10
   // 会話履歴を要約するためのシステムメッセージ
   protected summarizeSystemMessage: ChatCompletionSystemMessageParam = {
     role: 'system',
@@ -75,7 +77,7 @@ export class CharacterChatWithExpression {
    */
   constructor(
     systemMessages: ChatCompletionSystemMessageParam[] = [],
-    summarizeLength: number = 5,
+    summarizeLength: number = 10,
   ) {
     this.systemMessages = systemMessages
     this.summarizeLength = summarizeLength
@@ -151,7 +153,7 @@ export class CharacterChatWithExpression {
           // ツールレスポンスを含めて再度APIリクエスト
           const response = await openai.chat.completions.create({
             model,
-            messages: [...systemMessages, ...this.conversationHistory, toolMessage],
+            messages: [...systemMessages, ...this.conversationHistory],
             temperature: 0.7,
           })
 

--- a/src/utils/app/audioFromParagraphs.ts
+++ b/src/utils/app/audioFromParagraphs.ts
@@ -38,12 +38,16 @@ export async function audioQueriesFromParagraph(
   paragraph: Paragraph,
 ): Promise<VoiceVoxAudioQuery[]> {
   const sentences = splitSentence(paragraph.text)
-  const audioQueries = []
-  for (const sentence of sentences) {
-    const audioQuery = await requestAudioQuery(sentence, paragraph.speaker)
+  const audioQueries = (
+    await Promise.all(
+      sentences.map((sentence) => {
+        return requestAudioQuery(sentence, paragraph.speaker)
+      }),
+    )
+  ).map((audioQuery) => {
     audioQuery.speedScale = paragraph.speedScale
-    audioQueries.push(audioQuery)
-  }
+    return audioQuery
+  })
   return audioQueries
 }
 
@@ -51,11 +55,14 @@ export async function audioFromParagraph(paragraph: Paragraph): Promise<WavFileR
   if (paragraph.audioQueries === null) {
     paragraph.audioQueries = await audioQueriesFromParagraph(paragraph)
   }
-  const wavFiles = []
-  for (const audioQuery of paragraph.audioQueries) {
-    const buffer = await requestSynthesis(audioQuery, paragraph.speaker)
-    wavFiles.push(new WavFileReader(buffer))
-  }
+  const wavFiles = (
+    await Promise.all(
+      paragraph.audioQueries.map((audioQuery) => {
+        return requestSynthesis(audioQuery, paragraph.speaker)
+      }),
+    )
+  ).map((buffer) => new WavFileReader(buffer))
+
   if (wavFiles.length === 0) {
     return null
   }

--- a/src/utils/encoder/makeVideoEncoderConfig.ts
+++ b/src/utils/encoder/makeVideoEncoderConfig.ts
@@ -3,75 +3,75 @@
  */
 
 /**
- * 各種コーデックのタグを表す型
+ * ビデオコーデック情報の定義
  */
-export type VideoCodecTag = 'avc1' | 'hvc1' | 'vp8' | 'vp09' | 'av01'
-
-/**
- * 各種コーデックIDを表す型（WebMコンテナ用）
- */
-export type VideoMatroskaId = 'V_MPEG4/ISO/AVC' | 'V_MPEGH/ISO/HEVC' | 'V_VP8' | 'V_VP9' | 'V_AV1'
-
-/**
- * 各コーデックの文字列表現
- */
-const codecStr = {
-  avc: 'avc1.420034', // H.264コーデック
-  hevc: 'hvc1.1.6.L123.00', // H.265コーデック
-  vp8: 'vp8', // VP8コーデック
-  vp9: 'vp09.00.10.08', // VP9コーデック
-  av1: 'av01.0.04M.08', // AV1コーデック
+export const VIDEO_CODECS = {
+  avc1: {
+    codec: 'avc1.420034',
+    codecTag: 'avc1',
+    matroskaId: 'V_MPEG4/ISO/AVC',
+    defaultQP: 23,
+  },
+  hvc1: {
+    codec: 'hvc1.1.6.L123.00',
+    codecTag: 'hvc1',
+    matroskaId: 'V_MPEGH/ISO/HEVC',
+    defaultQP: 28,
+  },
+  vp8: {
+    codec: 'vp8',
+    codecTag: 'vp8',
+    matroskaId: 'V_VP8',
+    defaultQP: 10,
+  },
+  vp09: {
+    codec: 'vp09.00.10.08',
+    codecTag: 'vp09',
+    matroskaId: 'V_VP9',
+    defaultQP: 31,
+  },
+  av01: {
+    codec: 'av01.0.04M.08',
+    codecTag: 'av01',
+    matroskaId: 'V_AV1',
+    defaultQP: 35,
+  },
 } as const
 
-/**
- * コーデック情報を表すインターフェース
- */
-export interface VideoCodecInfo {
-  codec: string // コーデックの文字列表現
-  codecTag: VideoCodecTag // コーデックのタグ
-  matroskaId: VideoMatroskaId // コーデックID
-}
+// 型定義
+type ValueOf<T> = T[keyof T]
+export type VideoCodecInfo = ValueOf<typeof VIDEO_CODECS>
+export type VideoCodecStr = VideoCodecInfo['codec']
+export type VideoCodecTag = VideoCodecInfo['codecTag']
+export type VideoMatroskaId = VideoCodecInfo['matroskaId']
 
+/**
+ * エンコーダで試行するコーデックオプション
+ */
 type VideoCodecOption = Pick<VideoEncoderConfig, 'codec' | 'hardwareAcceleration'>
 
 /**
- * ビデオエンコーダの設定を作成する関数
- * 複数のコーデックを優先順位順に試し、サポートされている最初のものを使用する
- *
- * @param config - コーデックを除くビデオエンコーダの設定
- * @returns コーデック情報と設定をセットで返す、サポートされていない場合はnull
+ * 優先順位付きのコーデック設定リスト
  */
-export async function makeVideoEncoderConfig(config: Omit<VideoEncoderConfig, 'codec'>): Promise<{
+const PRIORITIZED_CODECS: VideoCodecOption[] = [
+  { codec: VIDEO_CODECS.av01.codec, hardwareAcceleration: 'prefer-hardware' },
+  { codec: VIDEO_CODECS.hvc1.codec, hardwareAcceleration: 'prefer-hardware' },
+  { codec: VIDEO_CODECS.vp09.codec, hardwareAcceleration: 'prefer-hardware' },
+  { codec: VIDEO_CODECS.hvc1.codec, hardwareAcceleration: 'prefer-software' },
+  { codec: VIDEO_CODECS.av01.codec, hardwareAcceleration: 'prefer-software' },
+  { codec: VIDEO_CODECS.vp09.codec, hardwareAcceleration: 'prefer-software' },
+  { codec: VIDEO_CODECS.avc1.codec, hardwareAcceleration: 'prefer-hardware' },
+  { codec: VIDEO_CODECS.avc1.codec, hardwareAcceleration: 'prefer-software' },
+  { codec: VIDEO_CODECS.vp8.codec, hardwareAcceleration: 'prefer-hardware' },
+  { codec: VIDEO_CODECS.vp8.codec, hardwareAcceleration: 'prefer-software' },
+]
+
+/**
+ * makeVideoEncoderConfigの戻り値の型
+ */
+interface VideoEncoderResult {
   codecInfo: VideoCodecInfo | null
   config: VideoEncoderConfig | null
-}> {
-  // 試行するコーデックの優先順位リスト
-  const codecs: VideoCodecOption[] = [
-    { codec: codecStr.av1, hardwareAcceleration: 'prefer-hardware' }, // AV1（ハードウェア優先）
-    { codec: codecStr.hevc, hardwareAcceleration: 'prefer-hardware' }, // HEVC（ハードウェア優先）
-    { codec: codecStr.vp9, hardwareAcceleration: 'prefer-hardware' }, // VP9（ハードウェア優先）
-    { codec: codecStr.hevc, hardwareAcceleration: 'prefer-software' }, // HEVC（ソフトウェア優先）
-    { codec: codecStr.av1, hardwareAcceleration: 'prefer-software' }, // AV1（ソフトウェア優先）
-    { codec: codecStr.vp9, hardwareAcceleration: 'prefer-software' }, // VP9（ソフトウェア優先）
-    { codec: codecStr.avc, hardwareAcceleration: 'prefer-hardware' }, // AVC（ハードウェア優先）
-    { codec: codecStr.avc, hardwareAcceleration: 'prefer-software' }, // AVC（ソフトウェア優先）
-    { codec: codecStr.vp8, hardwareAcceleration: 'prefer-hardware' }, // VP8（ハードウェア優先）
-    { codec: codecStr.vp8, hardwareAcceleration: 'prefer-software' }, // VP8（ソフトウェア優先）
-  ]
-
-  // サポートされている設定を探す
-  const supportedConfig = await findSupportedConfig(config, codecs)
-  if (!supportedConfig) {
-    return { codecInfo: null, config: null }
-  }
-
-  // 見つかった設定に対応するコーデック情報をマッピング
-  const codecInfo = mapCodecToInfo(supportedConfig.codec)
-  if (!codecInfo) {
-    return { codecInfo: null, config: null }
-  }
-
-  return { codecInfo, config: supportedConfig }
 }
 
 /**
@@ -86,40 +86,45 @@ async function findSupportedConfig(
   codecs: VideoCodecOption[],
 ): Promise<VideoEncoderConfig | null> {
   for (const { codec, hardwareAcceleration } of codecs) {
-    // 各コーデックでサポート状況をチェック
-    const videoEncodeSupport = await VideoEncoder.isConfigSupported({
-      ...baseConfig,
-      codec,
-      hardwareAcceleration,
-    })
-    if (videoEncodeSupport.supported && videoEncodeSupport.config) {
-      return videoEncodeSupport.config
-    } else {
-      console.log(`Not supported: ${codec} with ${hardwareAcceleration}`)
+    try {
+      const videoEncodeSupport = await VideoEncoder.isConfigSupported({
+        ...baseConfig,
+        codec,
+        hardwareAcceleration,
+      })
+
+      if (videoEncodeSupport.supported && videoEncodeSupport.config) {
+        return videoEncodeSupport.config
+      }
+    } catch (error) {
+      console.error(`Error checking support for ${codec}:`, error)
     }
+
+    console.log(`Not supported: ${codec} with ${hardwareAcceleration}`)
   }
   return null
 }
 
 /**
- * コーデック文字列からコーデック情報にマッピングする関数
+ * ビデオエンコーダの設定を作成する関数
+ * 複数のコーデックを優先順位順に試し、サポートされている最初のものを使用する
  *
- * @param codec - コーデックの文字列表現
- * @returns 対応するコーデック情報、または未対応の場合はnull
+ * @param config - コーデックを除くビデオエンコーダの設定
+ * @returns コーデック情報と設定をセットで返す、サポートされていない場合はnull
  */
-function mapCodecToInfo(codec: string | undefined): VideoCodecInfo | null {
-  switch (codec) {
-    case codecStr.avc:
-      return { codec, codecTag: 'avc1', matroskaId: 'V_MPEG4/ISO/AVC' }
-    case codecStr.hevc:
-      return { codec, codecTag: 'hvc1', matroskaId: 'V_MPEGH/ISO/HEVC' }
-    case codecStr.vp8:
-      return { codec, codecTag: 'vp8', matroskaId: 'V_VP8' }
-    case codecStr.vp9:
-      return { codec, codecTag: 'vp09', matroskaId: 'V_VP9' }
-    case codecStr.av1:
-      return { codec, codecTag: 'av01', matroskaId: 'V_AV1' }
-    default:
-      return null
+export async function makeVideoEncoderConfig(
+  config: Omit<VideoEncoderConfig, 'codec'>,
+): Promise<VideoEncoderResult> {
+  // サポートされている設定を探す
+  const supportedConfig = await findSupportedConfig(config, PRIORITIZED_CODECS)
+
+  if (!supportedConfig) {
+    return { codecInfo: null, config: null }
   }
+
+  // 見つかった設定に対応するコーデック情報をマッピング
+  const codecInfo =
+    Object.values(VIDEO_CODECS).find((info) => info.codec === supportedConfig.codec) || null
+
+  return { codecInfo, config: supportedConfig }
 }

--- a/src/views/VideoRenderView.vue
+++ b/src/views/VideoRenderView.vue
@@ -33,7 +33,7 @@ import { DEFAULT_EXPRESSION_MAP, type ExpressionMap, type ExpressionMapValue } f
 import { DEFAULT_PARAGRAPH, type Paragraph } from '@/utils/app/type/Paragraph';
 import type { ViewSetting } from '@/utils/app/type/ViewSetting';
 import { makeAudioEncoderConfig } from '@/utils/encoder/makeAudioEncoderConfig';
-import { makeVideoEncoderConfig } from '@/utils/encoder/makeVideoEncoderConfig';
+import { makeVideoEncoderConfig, VIDEO_CODECS } from '@/utils/encoder/makeVideoEncoderConfig';
 import { formatSrtTime } from '@/utils/subtitle/srt/formatSrtTime';
 import { loadSrt } from '@/utils/subtitle/srt/loadSrt';
 import { getDurationFromAudioQueries } from '@/utils/voicevox/getDurationFromAudioQuery';
@@ -201,12 +201,11 @@ async function startRender() {
 
 // Videoエンコーダー情報
 const videoCodec = ref<Awaited<ReturnType<typeof makeVideoEncoderConfig>> | null>(null)
+const qp = computed<number>(() => videoCodec.value?.codecInfo?.defaultQP ?? VIDEO_CODECS.hvc1.defaultQP)
 // Audioエンコーダー情報
 const audioCodec = ref<Awaited<ReturnType<typeof makeAudioEncoderConfig>> | null>(null)
 // マルチプレクサ
 const muxer = shallowRef<Muxer<ArrayBufferTarget> | null>(null)
-// ビデオエンコーダーの出力を受け取るバッファ
-const videoBuffer = shallowRef<ArrayBufferTarget>(new ArrayBufferTarget())
 // ビデオエンコーダーの初期化
 async function initEncoder() {
   // サポートされているビデオコーデックを取得
@@ -224,6 +223,7 @@ async function initEncoder() {
   if (!videoCodec.value.config) {
     throw new Error('Failed to get video encoder config')
   }
+
   // サポートされているオーディオコーデックを取得
   const audioQuery = paragraphs.value.find(paragraph => paragraph.audioQueries?.length)?.audioQueries?.[0]
   audioCodec.value = await makeAudioEncoderConfig({
@@ -239,7 +239,7 @@ async function initEncoder() {
 
   // マルチプレクサを初期化
   muxer.value = new Muxer({
-    target: videoBuffer.value,
+    target: new ArrayBufferTarget(),
     type: 'matroska',
     video: {
       width: viewSetting.value.canvasWidth,
@@ -319,6 +319,7 @@ async function onRendered() {
   audioEncoder.close()
 
   // マルチプレクサを終了
+  waitMessage.value = 'マルチプレクサをファイナライズ中...'
   muxer.value?.finalize()
 
   // ビデオとオーディオのURLを作成
@@ -412,7 +413,7 @@ onBeforeUnmount(() => {
                 <VCubismRenderLoopProvider :fps="isModelLoaded ? 1000 : 1">
                   <VVideoDeltaTimeProvider :fps="viewSetting.framerate" @timeupdate="onTimeUpdate">
                     <VVideoRecorder v-if="videoCodec?.config && isModelLoaded" :config="videoCodec.config"
-                      @video-encoder-output="onVideoEncoderOutput" :qp="8">
+                      @video-encoder-output="onVideoEncoderOutput" :qp="qp">
                     </VVideoRecorder>
                     <!-- モデルアセットを読み込み提供 -->
                     <VCubismModelAssetsProvider :model-home-dir="modelHomeDir" :model-file-name="modelFileName"
@@ -441,10 +442,10 @@ onBeforeUnmount(() => {
                         <VCubismModelAssetsRenderer />
                       </VCubismModelMatrixProvider>
                       <!-- モーションを管理するコンポーネント -->
-                      <VCubismMotionManager :group="currentExpression.motionGroupName"
-                        :index="currentExpression.motionIndex" />
+                      <VCubismMotionManager :group="currentExpression?.motionGroupName ?? null"
+                        :index="currentExpression?.motionIndex ?? null" />
                       <!-- 表情を管理するコンポーネント -->
-                      <VCubismExpressionManager :index="currentExpression.expressionIndex" />
+                      <VCubismExpressionManager :index="currentExpression?.expressionIndex ?? null" />
                     </VCubismModelAssetsProvider>
                   </VVideoDeltaTimeProvider>
                 </VCubismRenderLoopProvider>


### PR DESCRIPTION
- VParagraphsEditor.vue: 段落の開始時間を初期化するロジックを修正
- CharacterChatWithExpression.ts: キャラクターの表情変更関数の説明を詳細化し、会話履歴の要約長を変更
- audioFromParagraphs.ts: 音声クエリの取得処理を非同期で並列実行するように改善
- makeVideoEncoderConfig.ts: コーデック情報の定義を追加し、優先順位付きのコーデック設定リストを実装
- VideoRenderView.vue: ビデオエンコーダの初期化処理を修正し、QPの計算を改善