### PR TITLE
feat: 会話履歴の要約長を20に変更し、ツールコールを履歴に追加する機能を実装

### DIFF
--- a/src/livue2d/utils/app/CharacterChatWithExpression.ts
+++ b/src/livue2d/utils/app/CharacterChatWithExpression.ts
@@ -77,7 +77,7 @@ export class CharacterChatWithExpression {
    */
   constructor(
     systemMessages: ChatCompletionSystemMessageParam[] = [],
-    summarizeLength: number = 10,
+    summarizeLength: number = 20,
   ) {
     this.systemMessages = systemMessages
     this.summarizeLength = summarizeLength
@@ -141,6 +141,9 @@ export class CharacterChatWithExpression {
         if (functionCall.function.name === 'change_character_expression') {
           // 関数の引数をJSONとしてパース
           const args = JSON.parse(functionCall.function.arguments) as ChangeCharacterExpressionArgs
+
+          // ツールコールを履歴に追加
+          this.conversationHistory.push(message)
 
           // ツールレスポンスを作成
           const toolMessage: ChatCompletionToolMessageParam = {


### PR DESCRIPTION
- コンストラクタでの要約長を10から20に変更
- ツールコールを履歴に追加する処理を追加（これがないとOpenAI APIでエラーになったため） `messages with role 'tool' must be a response to a preceding message with 'tool_calls'`